### PR TITLE
Add SVG map support.

### DIFF
--- a/docs/Helper/Icon.md
+++ b/docs/Helper/Icon.md
@@ -72,6 +72,12 @@ Don't forget to also set up the necessary stylesheets (CSS files) and alike.
 
 Most icon sets can be rendered as inline SVG instead of using icon fonts or data attributes. This provides better customization, accessibility, and consistent rendering across browsers.
 
+SVG rendering supports two modes:
+- **Individual files**: Each icon is loaded from a separate `.svg` file. Use `cache` config to avoid extensive file lookups.
+- **JSON map**: All icons are loaded from a single JSON file containing SVG content.
+
+**JSON map mode is recommended** for better performance as it loads all icon definitions once instead of reading individual files.
+
 #### Bootstrap Icons
 
 ```php
@@ -102,6 +108,20 @@ Most icon sets can be rendered as inline SVG instead of using icon fonts or data
 
 #### Lucide
 
+**JSON Map (Recommended - Better Performance):**
+```php
+'Icon' => [
+    'sets' => [
+        'lucide' => [
+            'class' => \Templating\View\Icon\LucideIcon::class,
+            'svgPath' => WWW_ROOT . 'node_modules/lucide/dist/icons.json',
+        ],
+        ...
+    ],
+],
+```
+
+**Individual Files:**
 ```php
 'Icon' => [
     'sets' => [
@@ -135,6 +155,20 @@ The `svgPath` should point to the parent directory, and the class will automatic
 
 #### Feather Icons
 
+**JSON Map (Recommended - Better Performance):**
+```php
+'Icon' => [
+    'sets' => [
+        'feather' => [
+            'class' => \Templating\View\Icon\FeatherIcon::class,
+            'svgPath' => WWW_ROOT . 'node_modules/feather-icons/dist/icons.json',
+        ],
+        ...
+    ],
+],
+```
+
+**Individual Files:**
 ```php
 'Icon' => [
     'sets' => [
@@ -169,6 +203,22 @@ The `svgPath` should point to the parent directory, and the class will automatic
 - No need to load icon font files
 - Smaller file sizes when using only a subset of icons
 
+#### JSON Map vs Individual Files
+
+**JSON Map Mode:**
+- Single file load (entire icon library at once)
+- Better performance (no per-icon I/O)
+- Cached in memory and optionally in CakePHP cache
+- Automatically detected when `svgPath` ends with `.json`
+- **Recommended for production**
+
+**Individual Files Mode:**
+- Each icon loaded from separate `.svg` file
+- Useful for development or when using only a few icons
+- Automatically used when `svgPath` points to a directory
+
+The mode is automatically detected based on whether `svgPath` ends with `.json`.
+
 #### Optional: Enable Caching
 
 For better performance, you can enable CakePHP caching for SVG files:
@@ -186,7 +236,36 @@ For better performance, you can enable CakePHP caching for SVG files:
 ],
 ```
 
-When `svgPath` is configured, the icon will be rendered as an inline SVG element loaded from the configured directory. Icons are cached in memory per request, and optionally in your configured CakePHP cache for persistence across requests.
+When `svgPath` is configured, the icon will be rendered as an inline SVG element loaded from the configured directory or JSON map. Icons are cached in memory per request, and optionally in your configured CakePHP cache for persistence across requests.
+
+#### Customizing SVG Attributes (JSON Map Mode)
+
+When using JSON map mode, you can customize the default SVG wrapper attributes:
+
+```php
+'Icon' => [
+    'sets' => [
+        'lucide' => [
+            'class' => \Templating\View\Icon\LucideIcon::class,
+            'svgPath' => WWW_ROOT . 'node_modules/lucide/dist/icons.json',
+            'svgAttributes' => [
+                'xmlns' => 'http://www.w3.org/2000/svg',
+                'width' => '24',
+                'height' => '24',
+                'viewBox' => '0 0 24 24',
+                'fill' => 'none',
+                'stroke' => 'currentColor',
+                'stroke-width' => '2',
+                'stroke-linecap' => 'round',
+                'stroke-linejoin' => 'round',
+            ],
+        ],
+        ...
+    ],
+],
+```
+
+These attributes are used as defaults when wrapping the SVG content from the JSON map. Custom attributes passed during rendering will override these defaults.
 
 ## Usage
 

--- a/src/View/Icon/SvgRenderTrait.php
+++ b/src/View/Icon/SvgRenderTrait.php
@@ -13,6 +13,11 @@ trait SvgRenderTrait {
 	protected static array $svgCache = [];
 
 	/**
+	 * @var array<string, array<string, string>>
+	 */
+	protected static array $svgMapCache = [];
+
+	/**
 	 * Render SVG icon inline
 	 *
 	 * @param string $icon
@@ -21,6 +26,12 @@ trait SvgRenderTrait {
 	 * @return \Templating\View\HtmlStringable
 	 */
 	protected function renderSvg(string $icon, array $attributes = []): HtmlStringable {
+		// Check if using JSON map mode
+		if ($this->isJsonMapMode()) {
+			return $this->renderSvgFromMap($icon, $attributes);
+		}
+
+		// Original file-based approach
 		$svgPath = $this->getSvgPath($icon);
 
 		if (!isset(static::$svgCache[$svgPath])) {
@@ -60,6 +71,116 @@ trait SvgRenderTrait {
 		}
 
 		return $this->wrap($svgContent);
+	}
+
+	/**
+	 * Check if JSON map mode is enabled
+	 *
+	 * @return bool
+	 */
+	protected function isJsonMapMode(): bool {
+		$svgPath = $this->config['svgPath'] ?? null;
+
+		return $svgPath && str_ends_with($svgPath, '.json');
+	}
+
+	/**
+	 * Render SVG from JSON map
+	 *
+	 * @param string $icon
+	 * @param array<string, mixed> $attributes
+	 *
+	 * @return \Templating\View\HtmlStringable
+	 */
+	protected function renderSvgFromMap(string $icon, array $attributes = []): HtmlStringable {
+		$map = $this->loadSvgMap();
+
+		if (!isset($map[$icon])) {
+			throw new \RuntimeException(sprintf('SVG icon not found in map: %s', $icon));
+		}
+
+		$svgContent = $this->wrapSvgContent($map[$icon], $attributes);
+
+		return $this->wrap($svgContent);
+	}
+
+	/**
+	 * Load SVG map from JSON file
+	 *
+	 * @return array<string, string>
+	 */
+	protected function loadSvgMap(): array {
+		$jsonPath = $this->config['svgPath'];
+		$cacheKey = static::class . '_svg_map';
+
+		// Check static cache
+		if (isset(static::$svgMapCache[$cacheKey])) {
+			return static::$svgMapCache[$cacheKey];
+		}
+
+		$map = null;
+
+		// Try CakePHP cache if configured
+		if ($this->config['cache']) {
+			$map = Cache::read($cacheKey, $this->config['cache']);
+		}
+
+		// Load from JSON file if not in cache
+		if ($map === null) {
+			if (!file_exists($jsonPath)) {
+				throw new \RuntimeException(sprintf('SVG map file not found: %s', $jsonPath));
+			}
+
+			$content = file_get_contents($jsonPath);
+			if ($content === false) {
+				throw new \RuntimeException(sprintf('Failed to read SVG map file: %s', $jsonPath));
+			}
+
+			$map = json_decode($content, true);
+			if (!is_array($map)) {
+				throw new \RuntimeException(sprintf('Invalid JSON in SVG map file: %s', $jsonPath));
+			}
+
+			// Store in CakePHP cache if configured
+			if ($this->config['cache']) {
+				Cache::write($cacheKey, $map, $this->config['cache']);
+			}
+		}
+
+		static::$svgMapCache[$cacheKey] = $map;
+
+		return $map;
+	}
+
+	/**
+	 * Wrap SVG content from map with proper SVG tags
+	 *
+	 * @param string $content
+	 * @param array<string, mixed> $attributes
+	 *
+	 * @return string
+	 */
+	protected function wrapSvgContent(string $content, array $attributes = []): string {
+		// Get default SVG attributes from config or use defaults
+		$defaultAttrs = $this->config['svgAttributes'] ?? [
+			'xmlns' => 'http://www.w3.org/2000/svg',
+			'width' => '24',
+			'height' => '24',
+			'viewBox' => '0 0 24 24',
+			'fill' => 'none',
+			'stroke' => 'currentColor',
+			'stroke-width' => '2',
+			'stroke-linecap' => 'round',
+			'stroke-linejoin' => 'round',
+		];
+
+		// Merge with custom attributes
+		$svgAttrs = array_merge($defaultAttrs, $attributes);
+
+		// Build attributes string
+		$attrString = $this->template->formatAttributes($svgAttrs);
+
+		return '<svg' . $attrString . '>' . $content . '</svg>';
 	}
 
 	/**

--- a/src/View/Icon/SvgRenderTrait.php
+++ b/src/View/Icon/SvgRenderTrait.php
@@ -111,7 +111,7 @@ trait SvgRenderTrait {
 	 */
 	protected function loadSvgMap(): array {
 		$jsonPath = $this->config['svgPath'];
-		$cacheKey = static::class . '_svg_map';
+		$cacheKey = static::class . '_svg_map_' . md5($jsonPath);
 
 		// Check static cache
 		if (isset(static::$svgMapCache[$cacheKey])) {

--- a/tests/TestCase/View/Icon/FeatherIconTest.php
+++ b/tests/TestCase/View/Icon/FeatherIconTest.php
@@ -29,4 +29,55 @@ class FeatherIconTest extends TestCase {
 		$this->assertSame('<span data-feather="view"></span>', (string)$result);
 	}
 
+	/**
+	 * @return void
+	 */
+	public function testRenderSvgFromJsonMap(): void {
+		$jsonFile = TMP . 'tests' . DS . 'feather-icons.json';
+		$jsonContent = json_encode([
+			'activity' => '<polyline points="22 12 18 12 15 21 9 3 6 12 2 12"></polyline>',
+			'home' => '<path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"></path><polyline points="9 22 9 12 15 12 15 22"></polyline>',
+		]);
+		file_put_contents($jsonFile, $jsonContent);
+
+		$icon = new FeatherIcon([
+			'svgPath' => $jsonFile,
+		]);
+
+		$result = $icon->render('activity');
+		$resultString = (string)$result;
+
+		$this->assertStringContainsString('<svg', $resultString);
+		$this->assertStringContainsString('viewBox="0 0 24 24"', $resultString);
+		$this->assertStringContainsString('points="22 12 18 12 15 21 9 3 6 12 2 12"', $resultString);
+		$this->assertStringContainsString('</svg>', $resultString);
+
+		unlink($jsonFile);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testRenderSvgFromJsonMapWithCustomAttributes(): void {
+		$jsonFile = TMP . 'tests' . DS . 'feather-icons-custom.json';
+		$jsonContent = json_encode([
+			'star' => '<polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2"></polygon>',
+		]);
+		file_put_contents($jsonFile, $jsonContent);
+
+		$icon = new FeatherIcon([
+			'svgPath' => $jsonFile,
+		]);
+
+		$result = $icon->render('star', [], ['class' => 'star-icon', 'width' => '32', 'height' => '32']);
+		$resultString = (string)$result;
+
+		$this->assertStringContainsString('<svg', $resultString);
+		$this->assertStringContainsString('class="star-icon"', $resultString);
+		$this->assertStringContainsString('width="32"', $resultString);
+		$this->assertStringContainsString('height="32"', $resultString);
+
+		unlink($jsonFile);
+	}
+
 }

--- a/tests/TestCase/View/Icon/LucideIconTest.php
+++ b/tests/TestCase/View/Icon/LucideIconTest.php
@@ -95,4 +95,76 @@ class LucideIconTest extends TestCase {
 		$icon->render('nonexistent-icon');
 	}
 
+	/**
+	 * @return void
+	 */
+	public function testRenderSvgFromJsonMap(): void {
+		$jsonFile = TMP . 'tests' . DS . 'lucide-icons.json';
+		$jsonContent = json_encode([
+			'home' => '<path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/>',
+			'user' => '<path d="M19 21v-2a4 4 0 0 0-4-4H9a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/>',
+		]);
+		file_put_contents($jsonFile, $jsonContent);
+
+		$icon = new LucideIcon([
+			'svgPath' => $jsonFile,
+		]);
+
+		$result = $icon->render('home');
+		$resultString = (string)$result;
+
+		$this->assertStringContainsString('<svg', $resultString);
+		$this->assertStringContainsString('viewBox="0 0 24 24"', $resultString);
+		$this->assertStringContainsString('m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z', $resultString);
+		$this->assertStringContainsString('</svg>', $resultString);
+
+		unlink($jsonFile);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testRenderSvgFromJsonMapWithAttributes(): void {
+		$jsonFile = TMP . 'tests' . DS . 'lucide-icons-attrs.json';
+		$jsonContent = json_encode([
+			'heart' => '<path d="M19 14c1.49-1.46 3-3.21 3-5.5A5.5 5.5 0 0 0 16.5 3c-1.76 0-3 .5-4.5 2-1.5-1.5-2.74-2-4.5-2A5.5 5.5 0 0 0 2 8.5c0 2.3 1.5 4.05 3 5.5l7 7Z"/>',
+		]);
+		file_put_contents($jsonFile, $jsonContent);
+
+		$icon = new LucideIcon([
+			'svgPath' => $jsonFile,
+		]);
+
+		$result = $icon->render('heart', [], ['class' => 'custom-icon', 'data-test' => 'value']);
+		$resultString = (string)$result;
+
+		$this->assertStringContainsString('<svg', $resultString);
+		$this->assertStringContainsString('class="custom-icon"', $resultString);
+		$this->assertStringContainsString('data-test="value"', $resultString);
+
+		unlink($jsonFile);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testRenderSvgFromJsonMapThrowsExceptionWhenIconNotFound(): void {
+		$jsonFile = TMP . 'tests' . DS . 'lucide-icons-missing.json';
+		$jsonContent = json_encode([
+			'home' => '<path d="..."/>',
+		]);
+		file_put_contents($jsonFile, $jsonContent);
+
+		$icon = new LucideIcon([
+			'svgPath' => $jsonFile,
+		]);
+
+		$this->expectException(\RuntimeException::class);
+		$this->expectExceptionMessage('SVG icon not found in map: nonexistent');
+
+		$icon->render('nonexistent');
+
+		unlink($jsonFile);
+	}
+
 }


### PR DESCRIPTION
SVG rendering supports two modes:
- **Individual files**: Each icon is loaded from a separate `.svg` file. Use `cache` config to avoid extensive file lookups.
- **JSON map**: All icons are loaded from a single JSON file containing SVG content.

**JSON map mode is recommended** for better performance as it loads all icon definitions once instead of reading individual files.
