### PR TITLE
Add support for svg inlining

### DIFF
--- a/docs/Helper/Icon.md
+++ b/docs/Helper/Icon.md
@@ -116,6 +116,7 @@ Lucide uses individual SVG files. The `lucide-static` package is recommended for
         'lucide' => [
             'class' => \Templating\View\Icon\LucideIcon::class,
             'svgPath' => WWW_ROOT . 'node_modules/lucide-static/icons/',
+            'inline' => true, // Optional: compress SVG output
         ],
         ...
     ],
@@ -258,6 +259,48 @@ When using JSON map mode, you can customize the default SVG wrapper attributes:
 ```
 
 These attributes are used as defaults when wrapping the SVG content from the JSON map. Custom attributes passed during rendering will override these defaults.
+
+#### SVG Inlining
+
+When using SVG rendering, you can enable the `inline` option to optimize SVG output by removing HTML comments and compressing whitespace. This is particularly useful for production environments to reduce file size.
+
+```php
+'Icon' => [
+    'sets' => [
+        'lucide' => [
+            'class' => MyIconClass::class,
+            'svgPath' => 'path/to/svg_icons',
+            'inline' => true, // Strips comments and whitespace from SVG content
+        ],
+        ...
+    ],
+],
+```
+
+The inlining process:
+- Removes HTML comments
+- Strips unnecessary whitespace and newlines
+- Preserves spaces within quoted attribute values
+- Compresses the SVG while maintaining functionality
+
+**Before inlining:**
+```xml
+<!-- HTML comment -->
+<svg
+  xmlns="http://www.w3.org/2000/svg"
+  width="24"
+  height="24"
+>
+  <path d="M15 21v-8a1 1 0 0 0-1-1h-4a1 1 0 0 0-1 1v8" />
+</svg>
+```
+
+**After inlining:**
+```xml
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"><path d="M15 21v-8a1 1 0 0 0-1-1h-4a1 1 0 0 0-1 1v8"/></svg>
+```
+
+This option is **disabled by default** to preserve the original SVG formatting during development.
 
 ## Usage
 

--- a/docs/Helper/Icon.md
+++ b/docs/Helper/Icon.md
@@ -262,15 +262,20 @@ These attributes are used as defaults when wrapping the SVG content from the JSO
 
 #### SVG Inlining
 
-When using SVG rendering, you can enable the `inline` option to optimize SVG output by removing HTML comments and compressing whitespace. This is particularly useful for production environments to reduce file size.
+When using SVG rendering, you can control the `inline` option to optimize SVG output by removing HTML comments and compressing whitespace. This reduces file size and improves page load performance.
 
 ```php
 'Icon' => [
     'sets' => [
         'lucide' => [
-            'class' => MyIconClass::class,
-            'svgPath' => 'path/to/svg_icons',
-            'inline' => true, // Strips comments and whitespace from SVG content
+            'class' => \Templating\View\Icon\LucideIcon::class,
+            'svgPath' => WWW_ROOT . 'node_modules/lucide-static/icons/',
+            'inline' => true, // Explicitly enable inlining
+        ],
+        'bootstrap' => [
+            'class' => \Templating\View\Icon\BootstrapIcon::class,
+            'svgPath' => WWW_ROOT . 'css/bootstrap-icons/icons/',
+            'inline' => false, // Explicitly disable inlining
         ],
         ...
     ],
@@ -278,15 +283,22 @@ When using SVG rendering, you can enable the `inline` option to optimize SVG out
 ```
 
 The inlining process:
-- Removes HTML comments
+- Removes HTML comments (e.g., `<!-- license information -->`)  
 - Strips unnecessary whitespace and newlines
 - Preserves spaces within quoted attribute values
 - Compresses the SVG while maintaining functionality
 
+**Default Behavior:**
+- **Production** (`Configure::read('debug') === false`): `inline` defaults to `true`
+- **Development** (`Configure::read('debug') === true`): `inline` defaults to `false`
+
+This ensures optimized output in production while preserving readable formatting during development.
+
 **Before inlining:**
 ```xml
-<!-- HTML comment -->
+<!-- @license lucide-static v0.545.0 - ISC -->
 <svg
+  class="lucide lucide-home"
   xmlns="http://www.w3.org/2000/svg"
   width="24"
   height="24"
@@ -297,10 +309,10 @@ The inlining process:
 
 **After inlining:**
 ```xml
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24"><path d="M15 21v-8a1 1 0 0 0-1-1h-4a1 1 0 0 0-1 1v8"/></svg>
+<svg class="lucide lucide-home" xmlns="http://www.w3.org/2000/svg" width="24" height="24"><path d="M15 21v-8a1 1 0 0 0-1-1h-4a1 1 0 0 0-1 1v8"/></svg>
 ```
 
-This option is **disabled by default** to preserve the original SVG formatting during development.
+You can explicitly set `inline` to override the debug-based default for specific icon sets.
 
 ## Usage
 

--- a/src/View/Icon/BootstrapIcon.php
+++ b/src/View/Icon/BootstrapIcon.php
@@ -17,6 +17,7 @@ class BootstrapIcon extends AbstractIcon {
 			'template' => '<span class="{{class}}"{{attributes}}></span>',
 			'svgPath' => null,
 			'cache' => null,
+			'inline' => null,
 		];
 
 		parent::__construct($config);

--- a/src/View/Icon/FeatherIcon.php
+++ b/src/View/Icon/FeatherIcon.php
@@ -17,6 +17,7 @@ class FeatherIcon extends AbstractIcon {
 			'template' => '<span data-feather="{{name}}"{{attributes}}></span>',
 			'svgPath' => null,
 			'cache' => null,
+			'inline' => null,
 		];
 
 		parent::__construct($config);

--- a/src/View/Icon/FontAwesome4Icon.php
+++ b/src/View/Icon/FontAwesome4Icon.php
@@ -17,6 +17,7 @@ class FontAwesome4Icon extends AbstractIcon {
 			'template' => '<span class="{{class}}"{{attributes}}></span>',
 			'svgPath' => null,
 			'cache' => null,
+			'inline' => null,
 		];
 
 		parent::__construct($config);

--- a/src/View/Icon/FontAwesome5Icon.php
+++ b/src/View/Icon/FontAwesome5Icon.php
@@ -18,6 +18,7 @@ class FontAwesome5Icon extends AbstractIcon {
 			'namespace' => 'fas',
 			'svgPath' => null,
 			'cache' => null,
+			'inline' => null,
 		];
 
 		parent::__construct($config);

--- a/src/View/Icon/FontAwesome6Icon.php
+++ b/src/View/Icon/FontAwesome6Icon.php
@@ -19,6 +19,7 @@ class FontAwesome6Icon extends AbstractIcon {
 			'aliases' => true,
 			'svgPath' => null,
 			'cache' => null,
+			'inline' => null,
 		];
 
 		parent::__construct($config);

--- a/src/View/Icon/HeroiconsIcon.php
+++ b/src/View/Icon/HeroiconsIcon.php
@@ -18,6 +18,7 @@ class HeroiconsIcon extends AbstractIcon {
 			'style' => 'outline',
 			'svgPath' => null,
 			'cache' => null,
+			'inline' => null,
 		];
 
 		parent::__construct($config);

--- a/src/View/Icon/LucideIcon.php
+++ b/src/View/Icon/LucideIcon.php
@@ -17,6 +17,7 @@ class LucideIcon extends AbstractIcon {
 			'template' => '<span data-lucide="{{name}}"{{attributes}}></span>',
 			'svgPath' => null,
 			'cache' => null,
+			'inline' => null,
 		];
 
 		parent::__construct($config);

--- a/src/View/Icon/MaterialIcon.php
+++ b/src/View/Icon/MaterialIcon.php
@@ -18,6 +18,7 @@ class MaterialIcon extends AbstractIcon {
 			'namespace' => 'material-icons',
 			'svgPath' => null,
 			'cache' => null,
+			'inline' => null,
 		];
 
 		parent::__construct($config);

--- a/src/View/Icon/SvgRenderTrait.php
+++ b/src/View/Icon/SvgRenderTrait.php
@@ -276,9 +276,10 @@ trait SvgRenderTrait {
 			'/(["\'])(?:\\\\.|[^\\\\])*?\1|(\s+)/s',
 			function ($matches) {
 				// If group 1 matched, it's a quoted string: return as-is
-				if (isset($matches[1]) && $matches[1] !== '') {
+				if (!empty($matches[1])) {
 					return $matches[0];
 				}
+
 				// Otherwise, it's whitespace: collapse to a single space
 				return ' ';
 			},

--- a/src/View/Icon/SvgRenderTrait.php
+++ b/src/View/Icon/SvgRenderTrait.php
@@ -3,6 +3,7 @@
 namespace Templating\View\Icon;
 
 use Cake\Cache\Cache;
+use Cake\Core\Configure;
 use Templating\View\HtmlStringable;
 
 trait SvgRenderTrait {
@@ -70,8 +71,8 @@ trait SvgRenderTrait {
 			$svgContent = $this->addAttributesToSvg($svgContent, $attributes);
 		}
 
-		// Apply inlining if enabled
-		if ($this->config['inline'] ?? false) {
+		// Apply inlining if enabled (defaults to true in production)
+		if ($this->config['inline'] ?? !Configure::read('debug', false)) {
 			$svgContent = $this->inlineSvg($svgContent);
 		}
 
@@ -106,8 +107,8 @@ trait SvgRenderTrait {
 
 		$svgContent = $this->wrapSvgContent($map[$icon], $attributes);
 
-		// Apply inlining if enabled
-		if ($this->config['inline'] ?? false) {
+		// Apply inlining if enabled (defaults to true in production)
+		if ($this->config['inline'] ?? !Configure::read('debug', false)) {
 			$svgContent = $this->inlineSvg($svgContent);
 		}
 

--- a/src/View/Icon/SvgRenderTrait.php
+++ b/src/View/Icon/SvgRenderTrait.php
@@ -271,12 +271,15 @@ trait SvgRenderTrait {
 		// Remove HTML comments
 		$svgContent = (string)preg_replace('/<!--.*?-->/s', '', $svgContent);
 
-		// Remove unnecessary whitespace while preserving spaces between attributes and within text content
-		// First, protect spaces within quoted attribute values
+		// Collapse whitespace outside of quoted attribute values
 		$svgContent = (string)preg_replace_callback(
-			'/(\s+)(?=(?:[^"\']*["\'][^"\']*["\'])*[^"\']*$)/',
+			'/(["\'])(?:\\\\.|[^\\\\])*?\1|(\s+)/s',
 			function ($matches) {
-				// Only compress whitespace that's not inside quotes
+				// If group 1 matched, it's a quoted string: return as-is
+				if (isset($matches[1]) && $matches[1] !== '') {
+					return $matches[0];
+				}
+				// Otherwise, it's whitespace: collapse to a single space
 				return ' ';
 			},
 			$svgContent,
@@ -287,13 +290,6 @@ trait SvgRenderTrait {
 
 		// Remove leading and trailing whitespace
 		$svgContent = trim($svgContent);
-
-		// Remove newlines and multiple spaces
-		$svgContent = (string)preg_replace('/\s+/', ' ', $svgContent);
-
-		// Clean up spaces around tag boundaries
-		$svgContent = (string)preg_replace('/\s*>\s*/', '>', $svgContent);
-		$svgContent = (string)preg_replace('/\s*<\s*/', '<', $svgContent);
 
 		return $svgContent;
 	}

--- a/tests/TestCase/View/Helper/IconHelperTest.php
+++ b/tests/TestCase/View/Helper/IconHelperTest.php
@@ -32,10 +32,72 @@ class IconHelperTest extends TestCase {
 					'class' => MaterialIcon::class,
 					'path' => TEST_FILES . 'font_icon/material/index.d.ts',
 				],
+				'lucide' => [
+					'class' => \Templating\View\Icon\LucideIcon::class,
+					'svgPath' => TEST_FILES . 'font_icon' . DS . 'lucide_svg',
+				],
 			],
 		];
 
 		$this->Icon = new IconHelper(new View(null), $config);
+	}
+
+	/**
+	 * Test SVG inlining functionality through IconHelper
+	 *
+	 * @return void
+	 */
+	public function testIconSvgInlining(): void {
+		$config = [
+			'sets' => [
+				'lucide' => [
+					'class' => \Templating\View\Icon\LucideIcon::class,
+					'svgPath' => TEST_FILES . 'font_icon' . DS . 'lucide_svg',
+					'inline' => true,
+				],
+			],
+		];
+
+		$IconWithInline = new IconHelper(new View(null), $config);
+		$result = $IconWithInline->render('home');
+		$resultString = (string)$result;
+
+		// Should not contain license comment or newlines when inlined
+		$this->assertStringNotContainsString('<!-- @license lucide-static', $resultString);
+		$this->assertStringNotContainsString("\n", $resultString);
+
+		// Should still contain the SVG content
+		$this->assertStringContainsString('<svg', $resultString);
+		$this->assertStringContainsString('class="lucide lucide-home"', $resultString);
+	}
+
+	/**
+	 * Test SVG without inlining (default behavior)
+	 *
+	 * @return void
+	 */
+	public function testIconSvgWithoutInlining(): void {
+		$config = [
+			'sets' => [
+				'lucide' => [
+					'class' => \Templating\View\Icon\LucideIcon::class,
+					'svgPath' => TEST_FILES . 'font_icon' . DS . 'lucide_svg',
+					// inline not set, defaults to false
+				],
+			],
+		];
+
+		$IconWithoutInline = new IconHelper(new View(null), $config);
+		$result = $IconWithoutInline->render('home');
+		$resultString = (string)$result;
+
+		// Should contain license comment and newlines when not inlined
+		$this->assertStringContainsString('<!-- @license lucide-static', $resultString);
+		$this->assertStringContainsString("\n", $resultString);
+
+		// Should still contain the SVG content
+		$this->assertStringContainsString('<svg', $resultString);
+		$this->assertStringContainsString('class="lucide lucide-home"', $resultString);
 	}
 
 	/**

--- a/tests/TestCase/View/Icon/LucideIconTest.php
+++ b/tests/TestCase/View/Icon/LucideIconTest.php
@@ -427,4 +427,30 @@ class LucideIconTest extends TestCase {
 		$this->assertStringContainsString("\n", $resultString2);
 	}
 
+	/**
+	 * Test that explicit inline config overrides debug setting
+	 *
+	 * @return void
+	 */
+	public function testExplicitInlineOverridesDebug(): void {
+		$originalDebug = \Cake\Core\Configure::read('debug');
+		$svgPath = TEST_FILES . 'font_icon' . DS . 'lucide_svg';
+
+		try {
+			// Test: inline = true overrides debug = true
+			\Cake\Core\Configure::write('debug', true);
+			$icon = new LucideIcon(['svgPath' => $svgPath, 'inline' => true]);
+			$result = (string)$icon->render('home');
+			$this->assertStringNotContainsString('<!-- @license', $result);
+
+			// Test: inline = false overrides debug = false
+			\Cake\Core\Configure::write('debug', false);
+			$icon = new LucideIcon(['svgPath' => $svgPath, 'inline' => false]);
+			$result = (string)$icon->render('home');
+			$this->assertStringContainsString('<!-- @license', $result);
+		} finally {
+			\Cake\Core\Configure::write('debug', $originalDebug);
+		}
+	}
+
 }

--- a/tests/TestCase/View/Icon/LucideIconTest.php
+++ b/tests/TestCase/View/Icon/LucideIconTest.php
@@ -203,4 +203,228 @@ class LucideIconTest extends TestCase {
 		unlink($jsonFile);
 	}
 
+	/**
+	 * Test SVG inlining functionality with existing test files
+	 *
+	 * @return void
+	 */
+	public function testRenderSvgWithInlining(): void {
+		$svgPath = TEST_FILES . 'font_icon' . DS . 'lucide_svg';
+
+		$icon = new LucideIcon([
+			'svgPath' => $svgPath,
+			'inline' => true,
+		]);
+
+		$result = $icon->render('home');
+		$resultString = (string)$result;
+
+		// Should not contain license comment
+		$this->assertStringNotContainsString('<!-- @license lucide-static', $resultString);
+
+		// Should have compressed whitespace - no newlines or multiple spaces
+		$this->assertStringNotContainsString("\n", $resultString);
+		$this->assertStringNotContainsString('  ', $resultString);
+
+		// Should still contain the actual SVG content and attributes
+		$this->assertStringContainsString('<svg', $resultString);
+		$this->assertStringContainsString('viewBox="0 0 24 24"', $resultString);
+		$this->assertStringContainsString('class="lucide lucide-home"', $resultString);
+		$this->assertStringContainsString('stroke-width="2"', $resultString);
+		$this->assertStringContainsString('d="M15 21v-8a1 1 0 0 0-1-1h-4a1 1 0 0 0-1 1v8"', $resultString);
+	}
+
+	/**
+	 * Test SVG inlining functionality with JSON map mode
+	 *
+	 * @return void
+	 */
+	public function testRenderSvgFromJsonMapWithInlining(): void {
+		$jsonFile = TMP . 'tests' . DS . 'lucide-icons-inline.json';
+		$jsonContent = json_encode([
+			'clock' => '<!-- Comment in content -->
+<path d="M12 6v6l4 2"/>  
+<circle cx="12" cy="12" r="10"/>
+<!-- Another comment -->',
+		]);
+		file_put_contents($jsonFile, $jsonContent);
+
+		$icon = new LucideIcon([
+			'svgPath' => $jsonFile,
+			'inline' => true,
+		]);
+
+		$result = $icon->render('clock');
+		$resultString = (string)$result;
+
+		// Should not contain comments
+		$this->assertStringNotContainsString('<!-- Comment in content -->', $resultString);
+		$this->assertStringNotContainsString('<!-- Another comment -->', $resultString);
+
+		// Should have compressed whitespace
+		$this->assertStringNotContainsString("\n", $resultString);
+		$this->assertStringNotContainsString('  ', $resultString);
+
+		// Should still contain the actual SVG content wrapped properly
+		$this->assertStringContainsString('<svg', $resultString);
+		$this->assertStringContainsString('viewBox="0 0 24 24"', $resultString);
+		$this->assertStringContainsString('<path d="M12 6v6l4 2"/>', $resultString);
+		$this->assertStringContainsString('<circle cx="12" cy="12" r="10"/>', $resultString);
+
+		unlink($jsonFile);
+	}
+
+	/**
+	 * Test that inlining is disabled by default
+	 *
+	 * @return void
+	 */
+	public function testRenderSvgWithoutInlining(): void {
+		$svgPath = TEST_FILES . 'font_icon' . DS . 'lucide_svg';
+
+		$icon = new LucideIcon([
+			'svgPath' => $svgPath,
+			// inline not set, should default to false
+		]);
+
+		$result = $icon->render('home');
+		$resultString = (string)$result;
+
+		// Should contain comments and whitespace (not inlined)
+		$this->assertStringContainsString('<!-- @license lucide-static', $resultString);
+		$this->assertStringContainsString("\n", $resultString);
+		$this->assertStringContainsString('  ', $resultString);
+	}
+
+	/**
+	 * Test inlining preserves quoted attribute values properly
+	 *
+	 * @return void
+	 */
+	public function testInliningPreservesQuotedValues(): void {
+		$svgPath = TMP . 'tests' . DS . 'lucide-icons';
+		if (!is_dir($svgPath)) {
+			mkdir($svgPath, 0777, true);
+		}
+
+		$svgFile = $svgPath . DS . 'test-quotes.svg';
+		$svgContent = '<svg xmlns="http://www.w3.org/2000/svg" 
+     data-test="value with spaces" 
+     class="icon class-name">
+  <path d="M12 6 L16 8 L12 10"/>
+</svg>';
+		file_put_contents($svgFile, $svgContent);
+
+		$icon = new LucideIcon([
+			'svgPath' => $svgPath,
+			'inline' => true,
+		]);
+
+		$result = $icon->render('test-quotes');
+		$resultString = (string)$result;
+
+		// Should preserve spaces within quoted values
+		$this->assertStringContainsString('data-test="value with spaces"', $resultString);
+		$this->assertStringContainsString('class="icon class-name"', $resultString);
+		$this->assertStringContainsString('d="M12 6 L16 8 L12 10"', $resultString);
+
+		// But should remove other whitespace
+		$this->assertStringNotContainsString("\n", $resultString);
+
+		unlink($svgFile);
+	}
+
+	/**
+	 * Test inlining with mixed content including complex SVG elements
+	 *
+	 * @return void
+	 */
+	public function testInliningWithComplexSvg(): void {
+		$svgPath = TMP . 'tests' . DS . 'lucide-icons';
+		if (!is_dir($svgPath)) {
+			mkdir($svgPath, 0777, true);
+		}
+
+		$svgFile = $svgPath . DS . 'complex-test.svg';
+		$svgContent = '<!-- Complex SVG with various elements -->
+<svg xmlns="http://www.w3.org/2000/svg" 
+     viewBox="0 0 100 100"
+     class="complex-icon">
+  <!-- Group element -->
+  <g transform="scale(0.5)">
+    <!-- Multiple paths with complex data -->
+    <path d="M10 10 Q15 5 20 10 T30 10" fill="red"/>
+    
+    <circle cx="50" cy="50" r="20" 
+            stroke="blue" 
+            stroke-width="2"/>
+  </g>
+  
+  <!-- Text element -->
+  <text x="50" y="80" text-anchor="middle">Hello World</text>
+</svg>';
+		file_put_contents($svgFile, $svgContent);
+
+		$icon = new LucideIcon([
+			'svgPath' => $svgPath,
+			'inline' => true,
+		]);
+
+		$result = $icon->render('complex-test');
+		$resultString = (string)$result;
+
+		// Should remove comments
+		$this->assertStringNotContainsString('<!-- Complex SVG', $resultString);
+		$this->assertStringNotContainsString('<!-- Group element -->', $resultString);
+		$this->assertStringNotContainsString('<!-- Multiple paths', $resultString);
+		$this->assertStringNotContainsString('<!-- Text element -->', $resultString);
+
+		// Should compress whitespace
+		$this->assertStringNotContainsString("\n", $resultString);
+		$this->assertStringNotContainsString('  ', $resultString);
+
+		// Should preserve complex path data and text content
+		$this->assertStringContainsString('d="M10 10 Q15 5 20 10 T30 10"', $resultString);
+		$this->assertStringContainsString('text-anchor="middle"', $resultString);
+		$this->assertStringContainsString('>Hello World</text>', $resultString);
+		$this->assertStringContainsString('transform="scale(0.5)"', $resultString);
+
+		unlink($svgFile);
+	}
+
+	/**
+	 * Test that inline option can be overridden at render time
+	 *
+	 * @return void
+	 */
+	public function testInlineOptionInheritance(): void {
+		$svgPath = TEST_FILES . 'font_icon' . DS . 'lucide_svg';
+
+		// Test with inline enabled globally
+		$icon = new LucideIcon([
+			'svgPath' => $svgPath,
+			'inline' => true,
+		]);
+
+		$result = $icon->render('home');
+		$resultString = (string)$result;
+
+		// Should be inlined
+		$this->assertStringNotContainsString('<!-- @license', $resultString);
+		$this->assertStringNotContainsString("\n", $resultString);
+
+		// Test with inline disabled globally
+		$icon2 = new LucideIcon([
+			'svgPath' => $svgPath,
+			'inline' => false,
+		]);
+
+		$result2 = $icon2->render('home');
+		$resultString2 = (string)$result2;
+
+		// Should not be inlined
+		$this->assertStringContainsString('<!-- @license', $resultString2);
+		$this->assertStringContainsString("\n", $resultString2);
+	}
+
 }


### PR DESCRIPTION
This adds support for the `inline` option per set allowing to compact svg's making your document less bloated.