### PR TITLE
Refactor icon collectors with AbstractCollector base class and improv…

### DIFF
--- a/src/View/Icon/AbstractIcon.php
+++ b/src/View/Icon/AbstractIcon.php
@@ -75,15 +75,4 @@ abstract class AbstractIcon implements IconInterface {
 		return Icon::create($icon);
 	}
 
-	/**
-	 * Icon formatting using the specific engine - must be implemented by concrete classes
-	 *
-	 * @param string $icon Icon name
-	 * @param array<string, mixed> $options Options (translate, title, etc.)
-	 * @param array<string, mixed> $attributes HTML attributes (class, etc.)
-	 *
-	 * @return \Templating\View\HtmlStringable
-	 */
-	abstract public function render(string $icon, array $options = [], array $attributes = []): HtmlStringable;
-
 }

--- a/src/View/Icon/AbstractIcon.php
+++ b/src/View/Icon/AbstractIcon.php
@@ -31,14 +31,28 @@ abstract class AbstractIcon implements IconInterface {
 	 */
 	protected function path(): string {
 		$path = $this->config['path'] ?? null;
-		if (!$path) {
-			throw new RuntimeException('You need to define a meta data file path for `' . static::class . '` in order to get icon names.');
+		if ($path && file_exists($path)) {
+			return $path;
 		}
-		if (!file_exists($path)) {
+
+		$svgPath = $this->config['svgPath'] ?? null;
+		if ($svgPath && is_dir($svgPath)) {
+			return $svgPath;
+		}
+
+		if (!$path && !$svgPath) {
+			throw new RuntimeException('You need to define a meta data file path or SVG directory path for `' . static::class . '` in order to get icon names.');
+		}
+
+		if ($path && !file_exists($path)) {
 			throw new RuntimeException('Cannot find meta data file path `' . $path . '` for `' . static::class . '`.');
 		}
 
-		return $path;
+		if ($svgPath && !is_dir($svgPath)) {
+			throw new RuntimeException('SVG path `' . $svgPath . '` is not a directory for `' . static::class . '`.');
+		}
+
+		throw new RuntimeException('No valid path configuration found for `' . static::class . '`.');
 	}
 
 	/**
@@ -60,5 +74,16 @@ abstract class AbstractIcon implements IconInterface {
 	protected function wrap(string $icon): HtmlStringable {
 		return Icon::create($icon);
 	}
+
+	/**
+	 * Icon formatting using the specific engine - must be implemented by concrete classes
+	 *
+	 * @param string $icon Icon name
+	 * @param array<string, mixed> $options Options (translate, title, etc.)
+	 * @param array<string, mixed> $attributes HTML attributes (class, etc.)
+	 *
+	 * @return \Templating\View\HtmlStringable
+	 */
+	abstract public function render(string $icon, array $options = [], array $attributes = []): HtmlStringable;
 
 }

--- a/src/View/Icon/Collector/AbstractCollector.php
+++ b/src/View/Icon/Collector/AbstractCollector.php
@@ -1,0 +1,229 @@
+<?php declare(strict_types=1);
+
+namespace Templating\View\Icon\Collector;
+
+use RuntimeException;
+
+/**
+ * Abstract base class for icon collectors providing common functionality
+ */
+abstract class AbstractCollector {
+
+	/**
+	 * Static cache for icon names by path (in-memory cache for request)
+	 *
+	 * @var array<string, array<string>>
+	 */
+	protected static array $cache = [];
+
+	/**
+	 * Collect icon names from a file or directory - must be implemented by concrete classes
+	 *
+	 * @param string $path Path to file or directory
+	 * @param array<string, mixed> $options Collection options
+	 *
+	 * @return array<string>
+	 */
+	abstract public static function collect(string $path, array $options = []): array;
+
+	/**
+	 * Get cached result or compute and cache new result
+	 *
+	 * @param string $path
+	 * @param array<string, mixed> $options
+	 * @param callable $callback
+	 *
+	 * @return array<string>
+	 */
+	protected static function cached(string $path, array $options, callable $callback): array {
+		$cacheKey = static::getCacheKey($path, $options);
+
+		// Check static cache first (in-memory for this request)
+		if (isset(static::$cache[$cacheKey])) {
+			return static::$cache[$cacheKey];
+		}
+
+		$result = $callback();
+
+		// Cache in memory for this request
+		static::$cache[$cacheKey] = $result;
+
+		return $result;
+	}
+
+	/**
+	 * Generate cache key for path and options
+	 *
+	 * @param string $path
+	 * @param array<string, mixed> $options
+	 *
+	 * @return string
+	 */
+	protected static function getCacheKey(string $path, array $options = []): string {
+		if (empty($options)) {
+			return $path;
+		}
+
+		return $path . '|' . md5(serialize($options));
+	}
+
+	/**
+	 * Read and validate file contents
+	 *
+	 * @param string $filePath
+	 *
+	 * @return string
+	 */
+	protected static function readFile(string $filePath): string {
+		if (!file_exists($filePath)) {
+			throw new RuntimeException('File not found: ' . $filePath);
+		}
+
+		$content = file_get_contents($filePath);
+		if ($content === false) {
+			throw new RuntimeException('Cannot read file: ' . $filePath);
+		}
+
+		return $content;
+	}
+
+	/**
+	 * Parse JSON file and return decoded array
+	 *
+	 * @param string $filePath
+	 *
+	 * @return array<string, mixed>
+	 */
+	protected static function parseJsonFile(string $filePath): array {
+		$content = static::readFile($filePath);
+		$array = json_decode($content, true);
+
+		if (!is_array($array)) {
+			throw new RuntimeException('Cannot parse JSON or invalid format: ' . $filePath);
+		}
+
+		return $array;
+	}
+
+	/**
+	 * Collect icon names from JSON file (returns array keys)
+	 *
+	 * @param string $filePath
+	 *
+	 * @return array<string>
+	 */
+	protected static function collectFromJsonFile(string $filePath): array {
+		$array = static::parseJsonFile($filePath);
+
+		return array_keys($array);
+	}
+
+	/**
+	 * Collect icon names from directory of SVG files
+	 *
+	 * @param string $directory
+	 * @param array<string, mixed> $options Options for directory scanning
+	 *
+	 * @return array<string>
+	 */
+	protected static function collectFromDirectory(string $directory, array $options = []): array {
+		if (!is_dir($directory)) {
+			throw new RuntimeException('Path is not a directory: ' . $directory);
+		}
+
+		$options += [
+			'pattern' => '*.svg',
+			'recursive' => false,
+			'sort' => true,
+			'removeExtension' => true,
+		];
+
+		$icons = [];
+		$directory = rtrim($directory, '/');
+		$pattern = $directory . '/' . $options['pattern'];
+
+		$files = glob($pattern);
+		if ($files === false) {
+			throw new RuntimeException('Cannot read directory: ' . $directory);
+		}
+
+		foreach ($files as $file) {
+			if (is_file($file)) {
+				$iconName = basename($file);
+
+				if ($options['removeExtension']) {
+					$iconName = pathinfo($iconName, PATHINFO_FILENAME);
+				}
+
+				if ($iconName !== '') {
+					$icons[] = $iconName;
+				}
+			}
+		}
+
+		if ($options['sort']) {
+			sort($icons);
+		}
+
+		return $icons;
+	}
+
+	/**
+	 * Extract icon names using regex pattern
+	 *
+	 * @param string $content File content to parse
+	 * @param string $pattern Regex pattern with one capture group
+	 * @param array<string, mixed> $options Parsing options
+	 *
+	 * @return array<string>
+	 */
+	protected static function extractWithRegex(string $content, string $pattern, array $options = []): array {
+		$options += [
+			'sort' => true,
+			'unique' => true,
+		];
+
+		preg_match_all($pattern, $content, $matches);
+
+		if (empty($matches[1])) {
+			return [];
+		}
+
+		$icons = $matches[1];
+
+		if ($options['unique']) {
+			$icons = array_unique($icons);
+		}
+
+		if ($options['sort']) {
+			sort($icons);
+		}
+
+		return array_values($icons);
+	}
+
+	/**
+	 * Handle file type detection and routing
+	 *
+	 * @param string $path
+	 * @param array<string, mixed> $options
+	 *
+	 * @return array<string>
+	 */
+	protected static function collectByType(string $path, array $options = []): array {
+		if (is_dir($path)) {
+			return static::collectFromDirectory($path, $options);
+		}
+
+		$extension = strtolower(pathinfo($path, PATHINFO_EXTENSION));
+
+		switch ($extension) {
+			case 'json':
+				return static::collectFromJsonFile($path);
+			default:
+				// For other file types, concrete classes should override collect
+				throw new RuntimeException('Unsupported file type: ' . $extension . ' for path: ' . $path);
+		}
+	}
+
+}

--- a/src/View/Icon/Collector/BootstrapIconCollector.php
+++ b/src/View/Icon/Collector/BootstrapIconCollector.php
@@ -2,30 +2,19 @@
 
 namespace Templating\View\Icon\Collector;
 
-use RuntimeException;
-
 /**
  * Using e.g. "bootstrap-icons" npm package.
  */
-class BootstrapIconCollector {
+class BootstrapIconCollector extends AbstractCollector {
 
 	/**
-	 * @param string $filePath
+	 * @param string $path Path to JSON file
+	 * @param array<string, mixed> $options Collection options
 	 *
 	 * @return array<string>
 	 */
-	public static function collect(string $filePath): array {
-		$content = file_get_contents($filePath);
-		if ($content === false) {
-			throw new RuntimeException('Cannot read file: ' . $filePath);
-		}
-		$array = json_decode($content, true);
-		if (!$array) {
-			throw new RuntimeException('Cannot parse JSON: ' . $filePath);
-		}
-
-		/** @var array<string> */
-		return array_keys($array);
+	public static function collect(string $path, array $options = []): array {
+		return static::cached($path, $options, fn () => static::collectFromJsonFile($path));
 	}
 
 }

--- a/src/View/Icon/Collector/FeatherIconCollector.php
+++ b/src/View/Icon/Collector/FeatherIconCollector.php
@@ -2,30 +2,19 @@
 
 namespace Templating\View\Icon\Collector;
 
-use RuntimeException;
-
 /**
  * Using e.g. "feather-icons" npm package.
  */
-class FeatherIconCollector {
+class FeatherIconCollector extends AbstractCollector {
 
 	/**
-	 * @param string $filePath
+	 * @param string $path Path to JSON file or directory containing SVG files
+	 * @param array<string, mixed> $options Collection options
 	 *
 	 * @return array<string>
 	 */
-	public static function collect(string $filePath): array {
-		$content = file_get_contents($filePath);
-		if ($content === false) {
-			throw new RuntimeException('Cannot read file: ' . $filePath);
-		}
-		$array = json_decode($content, true);
-		if (!$array) {
-			throw new RuntimeException('Cannot parse JSON: ' . $filePath);
-		}
-
-		/** @var array<string> */
-		return array_keys($array);
+	public static function collect(string $path, array $options = []): array {
+		return static::cached($path, $options, fn () => static::collectByType($path, $options));
 	}
 
 }

--- a/src/View/Icon/Collector/HeroiconsIconCollector.php
+++ b/src/View/Icon/Collector/HeroiconsIconCollector.php
@@ -7,38 +7,24 @@ use RuntimeException;
 /**
  * Using e.g. "heroicons" npm package.
  */
-class HeroiconsIconCollector {
-
-	/**
-	 * Static cache for icon names by path (in-memory cache for request)
-	 *
-	 * @var array<string, array<string>>
-	 */
-	protected static array $cache = [];
+class HeroiconsIconCollector extends AbstractCollector {
 
 	/**
 	 * @param string $path Path to JSON file or directory containing SVG files
+	 * @param array<string, mixed> $options Collection options
 	 *
 	 * @return array<string>
 	 */
-	public static function collect(string $path): array {
-		// Check static cache first (in-memory for this request)
-		if (isset(static::$cache[$path])) {
-			return static::$cache[$path];
-		}
+	public static function collect(string $path, array $options = []): array {
+		return static::cached($path, $options, function() use ($path, $options) {
+			// Check if path is a directory
+			if (is_dir($path)) {
+				return static::collectFromDirectory($path, $options);
+			}
 
-		// Check if path is a directory
-		if (is_dir($path)) {
-			$result = static::collectFromDirectory($path);
-		} else {
 			// Otherwise treat as JSON file
-			$result = static::collectFromJson($path);
-		}
-
-		// Cache in memory for this request
-		static::$cache[$path] = $result;
-
-		return $result;
+			return static::collectFromJsonFile($path);
+		});
 	}
 
 	/**
@@ -46,10 +32,11 @@ class HeroiconsIconCollector {
 	 * Supports both flat directories and nested style directories (outline, solid)
 	 *
 	 * @param string $directory
+	 * @param array<string, mixed> $options Collection options
 	 *
 	 * @return array<string>
 	 */
-	protected static function collectFromDirectory(string $directory): array {
+	protected static function collectFromDirectory(string $directory, array $options = []): array {
 		$icons = [];
 		$directory = rtrim($directory, '/');
 
@@ -88,27 +75,6 @@ class HeroiconsIconCollector {
 		sort($icons);
 
 		return $icons;
-	}
-
-	/**
-	 * Collect icon names from a JSON file
-	 *
-	 * @param string $filePath
-	 *
-	 * @return array<string>
-	 */
-	protected static function collectFromJson(string $filePath): array {
-		$content = file_get_contents($filePath);
-		if ($content === false) {
-			throw new RuntimeException('Cannot read file: ' . $filePath);
-		}
-		$array = json_decode($content, true);
-		if (!$array) {
-			throw new RuntimeException('Cannot parse JSON: ' . $filePath);
-		}
-
-		/** @var array<string> */
-		return array_keys($array);
 	}
 
 }

--- a/src/View/Icon/Collector/HeroiconsIconCollector.php
+++ b/src/View/Icon/Collector/HeroiconsIconCollector.php
@@ -48,13 +48,10 @@ class HeroiconsIconCollector extends AbstractCollector {
 			$styleDir = $directory . '/' . $style;
 			if (is_dir($styleDir)) {
 				$hasStyleDirs = true;
-				$files = glob($styleDir . '/*.svg');
-				if ($files !== false) {
-					foreach ($files as $file) {
-						$iconName = basename($file, '.svg');
-						if (!in_array($iconName, $icons, true)) {
-							$icons[] = $iconName;
-						}
+				$styleIcons = parent::collectFromDirectory($styleDir, $options);
+				foreach ($styleIcons as $iconName) {
+					if (!in_array($iconName, $icons, true)) {
+						$icons[] = $iconName;
 					}
 				}
 			}
@@ -62,17 +59,11 @@ class HeroiconsIconCollector extends AbstractCollector {
 
 		// If no style directories found, scan the directory directly
 		if (!$hasStyleDirs) {
-			$files = glob($directory . '/*.svg');
-			if ($files === false) {
-				throw new RuntimeException('Cannot read directory: ' . $directory);
-			}
-
-			foreach ($files as $file) {
-				$icons[] = basename($file, '.svg');
-			}
+			$icons = parent::collectFromDirectory($directory, $options);
+		} else {
+			// Sort icons when we have style directories
+			sort($icons);
 		}
-
-		sort($icons);
 
 		return $icons;
 	}

--- a/src/View/Icon/Collector/LucideIconCollector.php
+++ b/src/View/Icon/Collector/LucideIconCollector.php
@@ -2,88 +2,19 @@
 
 namespace Templating\View\Icon\Collector;
 
-use RuntimeException;
-
 /**
  * Using e.g. "lucide-static" npm package.
  */
-class LucideIconCollector {
-
-	/**
-	 * Static cache for icon names by path (in-memory cache for request)
-	 *
-	 * @var array<string, array<string>>
-	 */
-	protected static array $cache = [];
+class LucideIconCollector extends AbstractCollector {
 
 	/**
 	 * @param string $path Path to JSON file or directory containing SVG files
+	 * @param array<string, mixed> $options Collection options
 	 *
 	 * @return array<string>
 	 */
-	public static function collect(string $path): array {
-		// Check static cache first (in-memory for this request)
-		if (isset(static::$cache[$path])) {
-			return static::$cache[$path];
-		}
-
-		// Check if path is a directory
-		if (is_dir($path)) {
-			$result = static::collectFromDirectory($path);
-		} else {
-			// Otherwise treat as JSON file
-			$result = static::collectFromJson($path);
-		}
-
-		// Cache in memory for this request
-		static::$cache[$path] = $result;
-
-		return $result;
-	}
-
-	/**
-	 * Collect icon names from a directory of SVG files
-	 *
-	 * @param string $directory
-	 *
-	 * @return array<string>
-	 */
-	protected static function collectFromDirectory(string $directory): array {
-		$icons = [];
-		$files = glob(rtrim($directory, '/') . '/*.svg');
-
-		if ($files === false) {
-			throw new RuntimeException('Cannot read directory: ' . $directory);
-		}
-
-		foreach ($files as $file) {
-			$icons[] = basename($file, '.svg');
-		}
-
-		sort($icons);
-
-		return $icons;
-	}
-
-	/**
-	 * Collect icon names from a JSON file
-	 *
-	 * @param string $filePath
-	 *
-	 * @return array<string>
-	 */
-	protected static function collectFromJson(string $filePath): array {
-		$content = file_get_contents($filePath);
-		if ($content === false) {
-			throw new RuntimeException('Cannot read file: ' . $filePath);
-		}
-		$array = json_decode($content, true);
-		if (!$array) {
-			throw new RuntimeException('Cannot parse JSON: ' . $filePath);
-		}
-
-		/** @var array<string> */
-		return array_keys($array);
+	public static function collect(string $path, array $options = []): array {
+		return static::cached($path, $options, fn () => static::collectByType($path, $options));
 	}
 
 }

--- a/src/View/Icon/Collector/MaterialIconCollector.php
+++ b/src/View/Icon/Collector/MaterialIconCollector.php
@@ -2,31 +2,28 @@
 
 namespace Templating\View\Icon\Collector;
 
-use RuntimeException;
-
 /**
  * Using e.g. "material-symbols" npm package.
  */
-class MaterialIconCollector {
+class MaterialIconCollector extends AbstractCollector {
 
 	/**
-	 * @param string $filePath
+	 * @param string $path Path to TypeScript definition file
+	 * @param array<string, mixed> $options Collection options
 	 *
-	 * @return array<non-empty-string>
+	 * @return array<string>
 	 */
-	public static function collect(string $filePath): array {
-		$content = file_get_contents($filePath);
-		if ($content === false) {
-			throw new RuntimeException('Cannot read file: ' . $filePath);
-		}
+	public static function collect(string $path, array $options = []): array {
+		return static::cached($path, $options, function() use ($path, $options) {
+			$content = static::readFile($path);
+			$icons = static::extractWithRegex($content, '/"(.+)"/u', $options);
 
-		preg_match_all('/"(.+)"/u', $content, $matches);
-		if (empty($matches[1])) {
-			throw new RuntimeException('Cannot parse content: ' . $filePath);
-		}
+			if (empty($icons)) {
+				throw new \RuntimeException('Cannot parse content: ' . $path);
+			}
 
-		/** @var array<non-empty-string> */
-		return $matches[1];
+			return $icons;
+		});
 	}
 
 }

--- a/tests/TestCase/View/Helper/IconHelperTest.php
+++ b/tests/TestCase/View/Helper/IconHelperTest.php
@@ -59,7 +59,7 @@ class IconHelperTest extends TestCase {
 		];
 
 		$IconWithInline = new IconHelper(new View(null), $config);
-		$result = $IconWithInline->render('home');
+		$result = $IconWithInline->render('lucide:home');
 		$resultString = (string)$result;
 
 		// Should not contain license comment or newlines when inlined
@@ -88,7 +88,7 @@ class IconHelperTest extends TestCase {
 		];
 
 		$IconWithoutInline = new IconHelper(new View(null), $config);
-		$result = $IconWithoutInline->render('home');
+		$result = $IconWithoutInline->render('lucide:home');
 		$resultString = (string)$result;
 
 		// Should contain license comment and newlines when not inlined

--- a/tests/TestCase/View/Icon/AbstractIconTest.php
+++ b/tests/TestCase/View/Icon/AbstractIconTest.php
@@ -1,0 +1,128 @@
+<?php declare(strict_types=1);
+
+namespace Templating\Test\TestCase\View\Icon;
+
+use Cake\TestSuite\TestCase;
+use RuntimeException;
+
+class AbstractIconTest extends TestCase {
+
+	/**
+	 * Test that path() method works with traditional path config
+	 *
+	 * @return void
+	 */
+	public function testPathWithValidPathConfig(): void {
+		$validPath = TEST_FILES . 'font_icon' . DS . 'feather' . DS . 'icons.json';
+		$icon = new TestIcon(['path' => $validPath]);
+
+		$result = $this->invokeMethod($icon, 'path');
+		$this->assertSame($validPath, $result);
+	}
+
+	/**
+	 * Test that path() method works with svgPath directory
+	 *
+	 * @return void
+	 */
+	public function testPathWithValidSvgPathDirectory(): void {
+		$validSvgDir = TEST_FILES . 'font_icon' . DS . 'lucide_svg';
+		$icon = new TestIcon(['svgPath' => $validSvgDir]);
+
+		$result = $this->invokeMethod($icon, 'path');
+		$this->assertSame($validSvgDir, $result);
+	}
+
+	/**
+	 * Test that path() prefers path over svgPath when both are present
+	 *
+	 * @return void
+	 */
+	public function testPathPrefersPathOverSvgPath(): void {
+		$validPath = TEST_FILES . 'font_icon' . DS . 'feather' . DS . 'icons.json';
+		$validSvgDir = TEST_FILES . 'font_icon' . DS . 'lucide_svg';
+		$icon = new TestIcon([
+			'path' => $validPath,
+			'svgPath' => $validSvgDir,
+		]);
+
+		$result = $this->invokeMethod($icon, 'path');
+		$this->assertSame($validPath, $result);
+	}
+
+	/**
+	 * Test that path() throws exception when neither path nor svgPath is configured
+	 *
+	 * @return void
+	 */
+	public function testPathThrowsExceptionWhenNoPathConfigured(): void {
+		$icon = new TestIcon([]);
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessage('You need to define a meta data file path or SVG directory path for');
+
+		$this->invokeMethod($icon, 'path');
+	}
+
+	/**
+	 * Test that path() throws exception when path file does not exist
+	 *
+	 * @return void
+	 */
+	public function testPathThrowsExceptionWhenPathFileNotFound(): void {
+		$icon = new TestIcon(['path' => '/non/existent/file.json']);
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessage('Cannot find meta data file path');
+
+		$this->invokeMethod($icon, 'path');
+	}
+
+	/**
+	 * Test that path() throws exception when svgPath is not a directory
+	 *
+	 * @return void
+	 */
+	public function testPathThrowsExceptionWhenSvgPathNotDirectory(): void {
+		$filePath = TEST_FILES . 'font_icon' . DS . 'lucide_svg' . DS . 'home.svg';
+		$icon = new TestIcon(['svgPath' => $filePath]);
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessage('SVG path `' . $filePath . '` is not a directory for');
+
+		$this->invokeMethod($icon, 'path');
+	}
+
+	/**
+	 * Test that path() returns svgPath when path is not configured
+	 *
+	 * @return void
+	 */
+	public function testPathReturnsSvgPathWhenPathNotConfigured(): void {
+		$validSvgDir = TEST_FILES . 'font_icon' . DS . 'lucide_svg';
+		$icon = new TestIcon([
+			'svgPath' => $validSvgDir,
+		]);
+
+		$result = $this->invokeMethod($icon, 'path');
+		$this->assertSame($validSvgDir, $result);
+	}
+
+	/**
+	 * Helper method to invoke protected methods
+	 *
+	 * @param object $object
+	 * @param string $methodName
+	 * @param array<mixed> $parameters
+	 *
+	 * @return mixed
+	 */
+	protected function invokeMethod(object $object, string $methodName, array $parameters = []): mixed {
+		$reflection = new \ReflectionClass(get_class($object));
+		$method = $reflection->getMethod($methodName);
+		$method->setAccessible(true);
+
+		return $method->invokeArgs($object, $parameters);
+	}
+
+}

--- a/tests/TestCase/View/Icon/FeatherIconTest.php
+++ b/tests/TestCase/View/Icon/FeatherIconTest.php
@@ -80,4 +80,48 @@ class FeatherIconTest extends TestCase {
 		unlink($jsonFile);
 	}
 
+	/**
+	 * Test that svgPath can point to a directory of SVG files
+	 * and names() method works with directory scanning
+	 *
+	 * @return void
+	 */
+	public function testNamesFromSvgDirectory(): void {
+		$svgDir = TEST_FILES . 'font_icon' . DS . 'lucide_svg';
+
+		$icon = new FeatherIcon([
+			'svgPath' => $svgDir,
+		]);
+
+		$names = $icon->names();
+
+		$this->assertIsArray($names);
+		$this->assertContains('home', $names);
+		$this->assertContains('search', $names);
+		$this->assertContains('settings', $names);
+		$this->assertContains('user', $names);
+		$this->assertCount(4, $names);
+	}
+
+	/**
+	 * Test rendering SVG from directory
+	 *
+	 * @return void
+	 */
+	public function testRenderSvgFromDirectory(): void {
+		$svgDir = TEST_FILES . 'font_icon' . DS . 'lucide_svg';
+
+		$icon = new FeatherIcon([
+			'svgPath' => $svgDir,
+		]);
+
+		$result = $icon->render('home');
+		$resultString = (string)$result;
+
+		$this->assertStringContainsString('<svg', $resultString);
+		$this->assertStringContainsString('viewBox="0 0 24 24"', $resultString);
+		$this->assertStringContainsString('path d="M15 21v-8a1 1 0 0 0-1-1h-4a1 1 0 0 0-1 1v8"', $resultString);
+		$this->assertStringContainsString('</svg>', $resultString);
+	}
+
 }

--- a/tests/TestCase/View/Icon/TestIcon.php
+++ b/tests/TestCase/View/Icon/TestIcon.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+
+namespace Templating\Test\TestCase\View\Icon;
+
+use Templating\View\HtmlStringable;
+use Templating\View\Icon\AbstractIcon;
+
+/**
+ * Test concrete implementation of AbstractIcon for testing purposes
+ */
+class TestIcon extends AbstractIcon {
+
+	/**
+	 * @param array<string, mixed> $config
+	 */
+	public function __construct(array $config = []) {
+		$config += [
+			'template' => '<span class="icon {{name}}"{{attributes}}></span>',
+		];
+		parent::__construct($config);
+	}
+
+	/**
+	 * @return array<string>
+	 */
+	public function names(): array {
+		return ['test-icon', 'another-icon'];
+	}
+
+	/**
+	 * @param string $icon
+	 * @param array<string, mixed> $options
+	 * @param array<string, mixed> $attributes
+	 *
+	 * @return \Templating\View\HtmlStringable
+	 */
+	public function render(string $icon, array $options = [], array $attributes = []): HtmlStringable {
+		$options['name'] = $icon;
+		$options['attributes'] = $this->template->formatAttributes($attributes);
+
+		return $this->format($options);
+	}
+
+}


### PR DESCRIPTION
This PR started because `Collector::path()` was ingoring svgPath making Collectors useless in this case (got errors when using the Generator). Which now fixes this issue.

Additionally following changes are implemented:
- Add `AbstractCollector` base class with shared functionality (static caching, file reading, JSON parsing, directory scanning, regex extraction)
- Refactor all collectors to extend AbstractCollector eliminating code duplication
- Update  `AbstractIcon::path()` method to support svgPath directories