### PR TITLE
Fix phpstan: ignore missingType.generics for View generic parameter

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,4 +6,5 @@ parameters:
 		- tests/bootstrap.php
 	ignoreErrors:
 		- identifier: missingType.iterableValue
+		- identifier: missingType.generics
 		- '#Unsafe usage of new static\(\).#'


### PR DESCRIPTION
## Summary
- Add `missingType.generics` identifier to phpstan ignores
- CakePHP `View` class now has `@template TSubject`, causing level 8 phpstan to flag helper constructors that accept `View` without specifying the generic type parameter