### PR TITLE
Fix deprecated title option usage in tests

### DIFF
--- a/tests/TestCase/View/Helper/IconHelperTest.php
+++ b/tests/TestCase/View/Helper/IconHelperTest.php
@@ -149,8 +149,8 @@ class IconHelperTest extends TestCase {
 	/**
 	 * @return void
 	 */
-	public function testIconWithCustomTitleAttributesViaOptions() {
-		$result = $this->Icon->render('m:save', ['title' => 'Save me'], ['class' => 'my-extra']);
+	public function testIconWithCustomTitleAttributes() {
+		$result = $this->Icon->render('m:save', [], ['class' => 'my-extra', 'title' => 'Save me']);
 		$expected = '<span class="material-icons my-extra" title="Save me">save</span>';
 		$this->assertSame($expected, (string)$result);
 	}


### PR DESCRIPTION
## Summary
- Updates test to use the new API pattern (title in attributes) instead of the deprecated pattern (title in options)
- This eliminates the `E_USER_DEPRECATED` warning triggered by the intentional deprecation notice in `IconCollection::render()`

The deprecation is intentional library behavior to guide users to the new API, but tests should use the new pattern.