### PR TITLE
Add FontAwesome 7 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A CakePHP plugin to
 
 You can use one or many of the following icon sets out of the box:
 - [Bootstrap](https://icons.getbootstrap.com/)
-- [FontAwesome](https://fontawesome.com/icons) v4/v5/v6
+- [FontAwesome](https://fontawesome.com/icons) v4/v5/v6/v7
 - [Material](https://fonts.google.com/icons)
 - [Feather](https://feathericons.com/)
 - [Lucide](https://lucide.dev/) (modern Feather fork with 1000+ icons)

--- a/docs/Helper/Icon.md
+++ b/docs/Helper/Icon.md
@@ -204,6 +204,7 @@ You can store default configurations in `config/app.php`:
 | Icon Set | Class | Icons | License | NPM Package |
 |----------|-------|-------|---------|-------------|
 | **Bootstrap Icons** | `BootstrapIcon` | 1,800+ | MIT | `bootstrap-icons` |
+| **FontAwesome v7** | `FontAwesome7Icon` | 2,000+ | Font Awesome | `@fortawesome/fontawesome-free` |
 | **FontAwesome v6** | `FontAwesome6Icon` | 2,000+ | Font Awesome | `@fortawesome/fontawesome-free` |
 | **FontAwesome v5** | `FontAwesome5Icon` | 1,600+ | Font Awesome | `fontawesome-free` |
 | **FontAwesome v4** | `FontAwesome4Icon` | 800+ | Font Awesome | `font-awesome` |
@@ -623,7 +624,11 @@ Icon set: fa6
 
 ### FontAwesome
 
-**Font-based rendering (FontAwesome 6):**
+> [!NOTE]
+> FontAwesome 7 uses the same CSS class syntax and metadata format as FontAwesome 6.
+> The `FontAwesome7Icon` class is provided as an alias for clarity and forward compatibility.
+
+**Font-based rendering (FontAwesome 6/7):**
 ```php
 'fa6' => [
     'class' => \Templating\View\Icon\FontAwesome6Icon::class,

--- a/src/View/Icon/FontAwesome7Icon.php
+++ b/src/View/Icon/FontAwesome7Icon.php
@@ -1,0 +1,13 @@
+<?php declare(strict_types=1);
+
+namespace Templating\View\Icon;
+
+/**
+ * Font Awesome 7 uses the same class syntax and metadata format as Font Awesome 6.
+ *
+ * This alias class is provided for clarity and forward compatibility.
+ *
+ * @see https://docs.fontawesome.com/upgrade/whats-changed
+ */
+class FontAwesome7Icon extends FontAwesome6Icon {
+}


### PR DESCRIPTION
## Summary

- Add `FontAwesome7Icon` class as alias to `FontAwesome6Icon`
- Update documentation to reflect FA7 support

FontAwesome 7 uses the same CSS class syntax and metadata format as v6, so no separate implementation is needed. The alias class is provided for clarity and forward compatibility.

Tested with FA7 npm package (`@fortawesome/fontawesome-free@7.2.0`) - the existing `FontAwesome6IconCollector` successfully parses both JSON metadata and SVG sprites from FA7.