### PR TITLE
Validate icon names; drop dead Serializable from Html

### DIFF
--- a/src/View/Html.php
+++ b/src/View/Html.php
@@ -4,12 +4,11 @@ namespace Templating\View;
 
 use InvalidArgumentException;
 use JsonSerializable;
-use Serializable;
 
 /**
  * Html value object
  */
-class Html implements HtmlStringable, Serializable, JsonSerializable {
+class Html implements HtmlStringable, JsonSerializable {
 
 	/**
 	 * @var string
@@ -39,21 +38,6 @@ class Html implements HtmlStringable, Serializable, JsonSerializable {
 	 */
 	public function __toString(): string {
 		return $this->html;
-	}
-
-	/**
-	 * @return string
-	 */
-	public function serialize(): string {
-		return $this->html;
-	}
-
-	/**
-	 * @param string $data
-	 *
-	 * @return void
-	 */
-	public function unserialize(string $data): void {
 	}
 
 	/**

--- a/src/View/Icon/HeroiconsIcon.php
+++ b/src/View/Icon/HeroiconsIcon.php
@@ -11,6 +11,25 @@ class HeroiconsIcon extends AbstractIcon {
 	use SvgRenderTrait;
 
 	/**
+	 * Allowed Heroicons style sub-directories.
+	 *
+	 * Anchored against the directories Heroicons ships (incl. v2 sized
+	 * variants). Keeps the `style` config value out of free-form path
+	 * concatenation and prevents traversal via misconfiguration.
+	 *
+	 * @var array<int, string>
+	 */
+	protected const ALLOWED_STYLES = [
+		'outline',
+		'solid',
+		'mini',
+		'24/outline',
+		'24/solid',
+		'20/solid',
+		'16/solid',
+	];
+
+	/**
 	 * @param array<string, mixed> $config
 	 */
 	public function __construct(array $config = []) {
@@ -72,9 +91,16 @@ class HeroiconsIcon extends AbstractIcon {
 			throw new RuntimeException('SVG path not configured. Set `svgPath` in configuration.');
 		}
 
-		$style = $this->config['style'];
+		$this->assertSafeIconName($icon);
 
-		return rtrim((string)$basePath, '/') . '/' . $style . '/' . $icon . '.svg';
+		$style = (string)$this->config['style'];
+		if (!in_array($style, static::ALLOWED_STYLES, true)) {
+			throw new RuntimeException(sprintf('Invalid Heroicons style: `%s`.', $style));
+		}
+
+		$basePath = rtrim((string)$basePath, '/');
+
+		return $this->confineToBasePath($basePath, $basePath . '/' . $style . '/' . $icon . '.svg');
 	}
 
 }

--- a/src/View/Icon/SvgRenderTrait.php
+++ b/src/View/Icon/SvgRenderTrait.php
@@ -10,6 +10,18 @@ use Templating\View\HtmlStringable;
 trait SvgRenderTrait {
 
 	/**
+	 * Allowed pattern for icon names used as a filesystem path component.
+	 *
+	 * Matches the union of identifiers shipped by the supported icon sets
+	 * (Heroicons, Lucide, Feather, FontAwesome, Material). Forward slashes,
+	 * backslashes, dots, and other path metacharacters are intentionally
+	 * excluded to prevent path traversal via attacker-controlled icon names.
+	 *
+	 * @var string
+	 */
+	protected static string $iconNamePattern = '/^[a-zA-Z0-9][a-zA-Z0-9_\-]*$/';
+
+	/**
 	 * @var array<string, string>
 	 */
 	protected static array $svgCache = [];
@@ -105,6 +117,8 @@ trait SvgRenderTrait {
 	 * @return \Templating\View\HtmlStringable
 	 */
 	protected function renderSvgFromMap(string $icon, array $attributes = []): HtmlStringable {
+		$this->assertSafeIconName($icon);
+
 		$map = $this->loadSvgMap();
 
 		if (!isset($map[$icon])) {
@@ -213,7 +227,68 @@ trait SvgRenderTrait {
 			throw new RuntimeException('SVG path not configured. Set `svgPath` in configuration.');
 		}
 
-		return rtrim((string)$basePath, '/') . '/' . $icon . '.svg';
+		$this->assertSafeIconName($icon);
+
+		$basePath = rtrim((string)$basePath, '/');
+
+		return $this->confineToBasePath($basePath, $basePath . '/' . $icon . '.svg');
+	}
+
+	/**
+	 * Validate that an icon name is safe to use as a filesystem path component.
+	 *
+	 * @param string $icon
+	 *
+	 * @throws \RuntimeException When the icon name contains disallowed characters.
+	 *
+	 * @return void
+	 */
+	protected function assertSafeIconName(string $icon): void {
+		if ($icon === '' || !preg_match(static::$iconNamePattern, $icon)) {
+			throw new RuntimeException(sprintf('Invalid icon name: `%s`.', $icon));
+		}
+	}
+
+	/**
+	 * Ensure that a resolved file path stays within the configured base directory.
+	 *
+	 * Uses realpath on the base directory and on the directory containing the
+	 * candidate file. The candidate file itself may not yet exist, so it is
+	 * intentionally not realpathed directly. If realpath of the base directory
+	 * fails (e.g. it is not a real directory), the candidate is rejected.
+	 *
+	 * @param string $basePath
+	 * @param string $candidate
+	 *
+	 * @throws \RuntimeException When the candidate is outside the base directory.
+	 *
+	 * @return string
+	 */
+	protected function confineToBasePath(string $basePath, string $candidate): string {
+		$realBase = realpath($basePath);
+		if ($realBase === false) {
+			// Base directory does not exist on disk. The downstream
+			// `file_exists()` check will produce the canonical
+			// "SVG icon file not found" error. The icon-name allow-list
+			// already prevents traversal through any non-resolvable base.
+			return $candidate;
+		}
+
+		$candidateDir = dirname($candidate);
+		$realCandidateDir = realpath($candidateDir);
+		if ($realCandidateDir === false) {
+			// Sub-directory does not (yet) exist; the downstream existence
+			// check will fail. Allow-list on the icon name still guarantees
+			// no traversal segments were spliced into the path.
+			return $candidate;
+		}
+
+		$separator = DIRECTORY_SEPARATOR;
+		if ($realCandidateDir !== $realBase && !str_starts_with($realCandidateDir . $separator, $realBase . $separator)) {
+			throw new RuntimeException(sprintf('Resolved SVG path escapes base directory: `%s`.', $candidate));
+		}
+
+		return $candidate;
 	}
 
 	/**

--- a/tests/TestCase/View/Icon/HeroiconsIconTest.php
+++ b/tests/TestCase/View/Icon/HeroiconsIconTest.php
@@ -138,4 +138,68 @@ class HeroiconsIconTest extends TestCase {
 		$icon->render('nonexistent-icon');
 	}
 
+	/**
+	 * Path traversal payloads must be rejected with a clear exception, not
+	 * resolved to files outside the configured icon directory.
+	 *
+	 * @return void
+	 */
+	public function testRenderSvgRejectsPathTraversalIconName(): void {
+		$svgPath = TMP . 'tests' . DS . 'heroicons';
+		$outlinePath = $svgPath . DS . 'outline';
+		if (!is_dir($outlinePath)) {
+			mkdir($outlinePath, 0777, true);
+		}
+
+		$icon = new HeroiconsIcon([
+			'svgPath' => $svgPath,
+		]);
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessage('Invalid icon name');
+
+		$icon->render('../../../../etc/passwd');
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testRenderSvgRejectsSlashesInIconName(): void {
+		$svgPath = TMP . 'tests' . DS . 'heroicons';
+		$outlinePath = $svgPath . DS . 'outline';
+		if (!is_dir($outlinePath)) {
+			mkdir($outlinePath, 0777, true);
+		}
+
+		$icon = new HeroiconsIcon([
+			'svgPath' => $svgPath,
+		]);
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessage('Invalid icon name');
+
+		$icon->render('foo/bar');
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testRenderSvgRejectsUnknownStyle(): void {
+		$svgPath = TMP . 'tests' . DS . 'heroicons';
+		$outlinePath = $svgPath . DS . 'outline';
+		if (!is_dir($outlinePath)) {
+			mkdir($outlinePath, 0777, true);
+		}
+
+		$icon = new HeroiconsIcon([
+			'svgPath' => $svgPath,
+			'style' => '../../etc',
+		]);
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessage('Invalid Heroicons style');
+
+		$icon->render('user');
+	}
+
 }

--- a/tests/TestCase/View/Icon/LucideIconTest.php
+++ b/tests/TestCase/View/Icon/LucideIconTest.php
@@ -98,6 +98,65 @@ class LucideIconTest extends TestCase {
 	}
 
 	/**
+	 * Path traversal payloads must be rejected with a clear exception.
+	 *
+	 * @return void
+	 */
+	public function testRenderSvgRejectsPathTraversalIconName(): void {
+		$svgPath = TMP . 'tests' . DS . 'lucide-icons';
+		if (!is_dir($svgPath)) {
+			mkdir($svgPath, 0777, true);
+		}
+
+		$icon = new LucideIcon([
+			'svgPath' => $svgPath,
+		]);
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessage('Invalid icon name');
+
+		$icon->render('../../../../etc/passwd');
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testRenderSvgRejectsBackslashesInIconName(): void {
+		$svgPath = TMP . 'tests' . DS . 'lucide-icons';
+		if (!is_dir($svgPath)) {
+			mkdir($svgPath, 0777, true);
+		}
+
+		$icon = new LucideIcon([
+			'svgPath' => $svgPath,
+		]);
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessage('Invalid icon name');
+
+		$icon->render('foo\\bar');
+	}
+
+	/**
+	 * @return void
+	 */
+	public function testRenderSvgRejectsEmptyIconName(): void {
+		$svgPath = TMP . 'tests' . DS . 'lucide-icons';
+		if (!is_dir($svgPath)) {
+			mkdir($svgPath, 0777, true);
+		}
+
+		$icon = new LucideIcon([
+			'svgPath' => $svgPath,
+		]);
+
+		$this->expectException(RuntimeException::class);
+		$this->expectExceptionMessage('Invalid icon name');
+
+		$icon->render('');
+	}
+
+	/**
 	 * @return void
 	 */
 	public function testRenderSvgFromJsonMap(): void {


### PR DESCRIPTION
## Summary

- Validate icon names against `[a-zA-Z0-9][a-zA-Z0-9_-]*` in `SvgRenderTrait::getSvgPath()` and `HeroiconsIcon::getSvgPath()` so that `../` / `\` / dot / slash payloads can no longer be spliced into the resolved SVG path.
- `realpath`-confine the resolved candidate to the configured `svgPath` base directory (when the base actually exists on disk); falls back gracefully to the existing "icon not found" error when it does not.
- Allow-list the Heroicons `style` config key against the directories Heroicons ships (`outline`, `solid`, `mini`, `24/outline`, `24/solid`, `20/solid`, `16/solid`).
- Run the icon-name allow-list defensively in JSON-map mode too.
- Drop the `Serializable` interface from `View\Html`. PHP 8.1 deprecated the interface, and the legacy `unserialize(string $data): void` body was empty — calling it directly would have left the typed `$html` property uninitialized on first access. `__serialize` / `__unserialize` remain and continue to round-trip cleanly.

## Why

Icon names flow from helper-level user code into a filesystem path with naive concatenation. Standard usage hard-codes the icon names, but a developer who passes user-controlled input (query string, DB content) into the helper would expose any readable `.svg`-suffixed file on disk via `..//` payloads. Cheap to defend against, no behavior change for valid icon names.

