### PR TITLE
Use plugin-specific i18n domain for translations

### DIFF
--- a/resources/locales/template.pot
+++ b/resources/locales/template.pot
@@ -1,0 +1,28 @@
+# LANGUAGE translation of CakePHP Application
+# Copyright YEAR NAME <EMAIL@ADDRESS>
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PROJECT VERSION\n"
+"POT-Creation-Date: 2026-05-04 03:38+0200\n"
+"PO-Revision-Date: YYYY-mm-DD HH:MM+ZZZZ\n"
+"Last-Translator: NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <EMAIL@ADDRESS>\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
+
+msgid "Yes"
+msgstr ""
+
+msgid "No"
+msgstr ""
+
+msgid "prev"
+msgstr ""
+
+msgid "next"
+msgstr ""
+

--- a/src/View/Icon/IconCollection.php
+++ b/src/View/Icon/IconCollection.php
@@ -175,7 +175,7 @@ class IconCollection {
 				// Only translate if attribute exists and is not null/false
 				if (isset($attributes[$titleField]) && $attributes[$titleField] !== false) {
 					if (!isset($options['translate']) || $options['translate'] !== false) {
-						$attributes[$titleField] = __($attributes[$titleField]);
+						$attributes[$titleField] = __d('template', $attributes[$titleField]);
 					}
 				}
 			}


### PR DESCRIPTION
## Summary

- Convert the 1 bare `__()` call in `IconCollection::process()` (icon-title translation) to `__d('template', ...)` so it uses the plugin's existing `template` domain instead of leaking into the host app's `default` domain. The 5 pre-existing `__d('template', ...)` calls in `IconSnippetHelper` already pointed at the same domain — `IconCollection` now matches them.
- Add `resources/locales/template.pot` (4 unique msgids) generated via `bin/cake i18n extract`.

I deliberately kept the existing `template` domain name rather than renaming to `templating` to match the plugin namespace. Renaming would silently break any downstream user who already maintains a `template.po` file, and there's no functional reason to switch.

Note on the POT: only the static `Yes` / `No` icon-status labels and the page navigation suffix survive extraction. The prev/next snippets build their msgid by concatenating a runtime suffix (`'prev' . $name`), and the `IconCollection` title call takes a runtime attribute value — neither is statically extractable, but both still resolve through the `template` domain at runtime.

## Verification (local)

- phpunit: 115 / 115
- phpstan: no errors
- phpcs: clean